### PR TITLE
Potential fix for code scanning alert no. 2: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/copyright-check.yml
+++ b/.github/workflows/copyright-check.yml
@@ -13,6 +13,8 @@ on:
 jobs:
   copyright-check:
     runs-on: ubuntu-latest
+    permissions:
+      contents: write
     
     steps:
     - name: Checkout repository


### PR DESCRIPTION
Potential fix for [https://github.com/johnzilla/trustedge/security/code-scanning/2](https://github.com/johnzilla/trustedge/security/code-scanning/2)

The best way to address this problem is to explicitly define a `permissions` block in the workflow YAML. This block can be set at the top-level of the workflow (applying to all jobs), or at the job level (for granular control). In this workflow, the only GitHub operation requiring elevated permissions is the `git push`, which requires `contents: write`. All other steps can run with read-only permissions. Thus, set the `permissions` field for the relevant job (`copyright-check`) to:

```yaml
permissions:
  contents: write
```

This grants write access to repository contents only for this job. Add this stanza immediately after the `runs-on: ubuntu-latest` line (currently line 15), indented appropriately, in file `.github/workflows/copyright-check.yml`.

No imports or other definitions are needed, only this YAML key addition.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
